### PR TITLE
add python module to load in psc

### DIFF
--- a/_posts/2022-01-01-psc-usage.md
+++ b/_posts/2022-01-01-psc-usage.md
@@ -165,7 +165,7 @@ month={Sept.-Oct.}
    ```
 2. Load modules and set environment
    ```bash
-   module load cuda/10.2.0 cudnn mkl
+   module load cuda/10.2.0 cudnn mkl python
    CUDAROOT=/jet/packages/spack/opt/spack/linux-centos8-zen/gcc-8.3.1/cuda-10.2.89-kz7u4ix6ed53nioz4ycqin3kujcim3bs
    ```
 3. Kaldi installation:


### PR DESCRIPTION
Also need to load the python module prior to installing ESPNet, which activates python 3.8.6. 
Default python without the module in PSC is 3.6.8. ESPNet requires >= 3.7 so installation will fail. 
Will be useful to have this info before everyone in the 11-751 class tries to use psc.