### PR TITLE
Remove absolute URLs, fix various bugs, add info to PSC usage post

### DIFF
--- a/_news/announcement_1.md
+++ b/_news/announcement_1.md
@@ -4,4 +4,4 @@ date: 2021-05-20 13:59:00-0400
 inline: true
 ---
 
-Our lab published 14 ICASSP paper in the up-coming ICASSP2021. Please check <a href="https://shinjiwlab.github.io/publications/">here</a> for details.
+Our lab published 14 ICASSP paper in the up-coming ICASSP2021. Please check <a href="/publications">here</a> for details.

--- a/_news/announcement_3.md
+++ b/_news/announcement_3.md
@@ -4,4 +4,4 @@ date: 2021-06-03 0:00:00-0400
 inline: true
 ---
 
-Our lab has 20 Interspeech paper accepted in the Interspeech2021. Detailed list will be available soon in <a href="https://shinjiwlab.github.io/publications/">publication page</a>.
+Our lab has 20 Interspeech paper accepted in the Interspeech2021. Detailed list will be available soon in <a href="/publications">publication page</a>.

--- a/_news/announcement_4.md
+++ b/_news/announcement_4.md
@@ -4,4 +4,4 @@ date: 2021-09-13 0:00:00-0400
 inline: true
 ---
 
-Our lab has 9 ASRU paper accepted in the ASRU2021. Detailed list is already available in <a href="https://shinjiwlab.github.io/publications/">publication page</a>.
+Our lab has 9 ASRU paper accepted in the ASRU2021. Detailed list is already available in <a href="/publications">publication page</a>.

--- a/_news/announcement_5.md
+++ b/_news/announcement_5.md
@@ -4,4 +4,4 @@ date: 2022-03-01 0:00:00-0400
 inline: true
 ---
 
-Our lab has 18 ICASSP paper accepted in the ICASSP2022. Detailed list is already available in <a href="https://shinjiwlab.github.io/publications/">publication page</a>.
+Our lab has 18 ICASSP paper accepted in the ICASSP2022. Detailed list is already available in <a href="/publications">publication page</a>.

--- a/_news/announcement_6.md
+++ b/_news/announcement_6.md
@@ -4,4 +4,4 @@ date: 2022-06-15 0:00:00-0400
 inline: true
 ---
 
-Our lab has 23 paper accepted in the Interspeech2022. Detailed list will be available in <a href="https://shinjiwlab.github.io/publications/">publication page</a>.
+Our lab has 23 paper accepted in the Interspeech2022. Detailed list will be available in <a href="/publications">publication page</a>.

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -13,9 +13,7 @@ This is Watanabe's Audio and Voice (WAV) Lab at the Language Technologies Instit
 
 
 <div class="col-sm mt-3 mt-md-0" style="display:table-cell; vertical-align:middle; text-align:center">
-	<a href="https://shinjiwlab.github.io/">
-        <img class="img-fluid rounded z-depth-1" src="{{ site.baseurl }}/assets/img/gallery/03-06-2022.jpg">
-    </a>
+    <img class="img-fluid rounded z-depth-1" src="{{ site.baseurl }}/assets/img/gallery/03-06-2022.jpg">
     <div class="caption">
         Our Lab Party at the Porch before Interspeech, 03.06.2022
     </div>

--- a/_pages/courses.md
+++ b/_pages/courses.md
@@ -9,10 +9,10 @@ order: 5
 
 ### 2023 Spring
 
-* [Speech Processing (11-692)](https://shinjiwlab.github.io/activities/2023/11692-2023s/)
+* [Speech Processing (11-692)]({% post_url 2022-01-16-11692-2023s %})
 
 ### 2022 Fall
 
-* [Speech Recognition and Understanding (11-751)](https://shinjiwlab.github.io/activities/2022/11751-2022f/)
+* [Speech Recognition and Understanding (11-751)]({% post_url 2022-08-29-11751-2022f %})
 
 

--- a/_pages/info.md
+++ b/_pages/info.md
@@ -8,17 +8,16 @@ order: 7
 
 This page has some information guidelines for members of WAVLab.
 
-* [TIR cluster use instructions (for ESPnet user)](https://shinjiwlab.github.io/activities/2022/tir-usage)
-* [AWS use instructions](https://shinjiwlab.github.io/activities/2022/aws-usage)
-* [PSC cluster use instructions](https://shinjiwlab.github.io/activities/2022/psc-usage)
-* [Delta cluster use instructions](https://shinjiwlab.github.io/activities/2023/delta-usage)
-* [ESPnet2 recipes](https://shinjiwlab.github.io/activities/2022/espnet2-recipe)
+* [TIR cluster use instructions (for ESPnet user)]({% post_url 2022-01-01-tir-usage %})
+* [AWS use instructions]({% post_url 2022-01-01-aws-usage %})
+* [PSC cluster use instructions]({% post_url 2022-01-01-psc-usage %})
+* [Delta cluster use instructions]({% post_url 2023-04-02-delta-usage %})
+* [ESPnet2 recipes]({% post_url 2022-01-01-espnet2-recipe %})
 * [Lab logos and slides template](https://github.com/shinjiwlab/lab_logo) (Need to request access)
-
 
 
 Our galleries
 
-* [2023 Gallery](https://shinjiwlab.github.io/activities/2023/2023-record/)
-* [2022 Gallery](https://shinjiwlab.github.io/activities/2022/2022-record/)
-* [2021 Gallery](https://shinjiwlab.github.io/activities/2022/2021-record/)
+* [2023 Gallery]({% post_url 2023-04-05-2023-record %})
+* [2022 Gallery]({% post_url 2022-12-31-2022-record %})
+* [2021 Gallery]({% post_url 2021-12-13-2021-record %})

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -8,12 +8,12 @@ order: 2
 ---
 
 
-- [2023 Papers](https://shinjiwlab.github.io/activities/2023/paper-list/)
-- [2022 Papers](https://shinjiwlab.github.io/activities/2022/paper-list/)
-- [2021 Papers](https://shinjiwlab.github.io/activities/2021/paper-list/)
-- [2020 Papers](https://shinjiwlab.github.io/activities/2020/paper-list/)
-- [2019 Papers](https://shinjiwlab.github.io/activities/2019/paper-list/)
-- [2018 Papers](https://shinjiwlab.github.io/activities/2018/paper-list/)
+- [2023 Papers]({% post_url 2023-03-14-paper-list %})
+- [2022 Papers]({% post_url 2022-12-31-paper-list %})
+- [2021 Papers]({% post_url 2021-12-31-paper-list %})
+- [2020 Papers]({% post_url 2020-12-31-paper-list %})
+- [2019 Papers]({% post_url 2019-12-31-paper-list %})
+- [2018 Papers]({% post_url 2018-12-31-paper-list %})
 
 
 <div class="publications">

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -19,7 +19,7 @@ order: 2
 <div class="publications">
 
 {% for y in page.years %}
-  <h2 class="year">{{y}}</h2>
+  <h2>{{ y }}</h2>
   {% bibliography -f papers -q @*[year={{y}}]* %}
 {% endfor %}
 

--- a/_posts/2022-01-01-espnet2-recipe.md
+++ b/_posts/2022-01-01-espnet2-recipe.md
@@ -8,7 +8,7 @@ comments: false
 
 ## 0. Installation 
 
-For PSC usage and kaldi/espnet installation, please refer to [this wiki](https://shinjiwlab.github.io/activities/2022/psc-usage).
+For PSC usage and kaldi/espnet installation, please refer to [this wiki]({% post_url 2022-01-01-psc-usage %}).
 
 ## 1. Introduction 
 

--- a/_posts/2022-01-01-psc-usage.md
+++ b/_posts/2022-01-01-psc-usage.md
@@ -181,6 +181,27 @@ comments: false
     # Other:
     slurm-tool v|version         Print versions of slurm-tool tool and slurm itself
     ```
+  * Simple helper script for minimum usage
+    ```
+    # ~/.sbatch_helper.py
+    # You can easily use it by adding the below line in .bashrc"
+    # alias my_sbatch="python3 ~/.sbatch_helper.py"
+
+    machine = int(input("CPU (0) GPU-16GB (1) GPU-32GB (2): "))
+    if machine == 0:
+        cpus = int(input("# of CPUs (Max 128): "))
+        cpus = f"--ntasks-per-node={cpus}"
+        gpus = ""
+    else:
+        gpus = int(input("# of GPUs (Max 8): "))
+        gpus = "-N 1 --gpus=v100-" + ["", "16", "32"][machine] + f":{gpus}"
+        cpus = "--cpus-per-gpu 5"
+
+    hours = int(input("# of hours (Max 48): "))
+
+    machine_name = ["RM", "GPU", "GPU"][machine]
+    print(f"sbatch -p {machine_name}-shared {gpus} {cpus} -t {hours}:00:00")
+    ```
 
 # Important
 * `Home` directory is of limited space. Please do most of your work in ocean storage (`$ cd ${PROJECT}`)


### PR DESCRIPTION
- Remove absolute URLs by using `post_url` + relative URLs
- Fix bug that doesn't show year on publication
- Remove absolute link attached to main page's image
- Add helper python function example for PSC usage