### PR TITLE
Add conference deadline tracker page

### DIFF
--- a/.github/workflows/update-conferences.yml
+++ b/.github/workflows/update-conferences.yml
@@ -1,0 +1,58 @@
+name: Update conference deadlines
+
+# Refreshes _data/conferences.yml from the ccfddl/ccf-deadlines dataset and
+# opens a pull request with the proposed changes for human review. It never
+# pushes to a deploy branch directly — a maintainer reviews and merges.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"   # every Monday 06:00 UTC
+  workflow_dispatch: {}    # allow manual runs from the Actions tab
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source branch
+        uses: actions/checkout@v4
+        with:
+          ref: source
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install "ruamel.yaml>=0.18"
+
+      - name: Refresh conference data
+        run: python scripts/update_conferences.py
+
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          base: source
+          branch: bot/update-conference-deadlines
+          delete-branch: true
+          add-paths: _data/conferences.yml
+          commit-message: "chore: refresh conference deadlines from ccfddl"
+          title: "Update conference deadlines from ccfddl"
+          labels: automated
+          body: |
+            Automated refresh of `_data/conferences.yml` from the
+            [ccfddl/ccf-deadlines](https://github.com/ccfddl/ccf-deadlines) dataset.
+
+            Only entries with a `ccfddl:` key are touched (ICASSP, Interspeech,
+            SLT, ICML, ICLR, NeurIPS); identity/curation fields
+            (`name`, `acronym`) are preserved. Manually-maintained
+            entries such as ARR are left untouched.
+
+            **Please verify the proposed dates against each conference's official
+            site before merging** — the upstream dataset is community-maintained
+            and can be incomplete or out of date. If there is nothing to update,
+            no PR is created.

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -64,6 +64,26 @@
   place: "Palermo, Sicily, Italy"
   url: https://attend.ieee.org/slt-2026/
 
+- name: IEEE SLT Workshop — Demo, System & Data / Challenge Papers
+  acronym: SLT Demo/Challenge
+  year: 2026
+  deadline: 2026-07-08 23:59
+  start: 2026-12-13
+  end: 2026-12-16
+  place: "Palermo, Sicily, Italy"
+  url: https://attend.ieee.org/slt-2026/call-for-demo-system-and-data-papers/
+  note: "Shared deadline (AoE) for demo/system/data papers and challenge papers; separate from the main SLT paper deadline."
+
+- name: Speech and Audio in the Northeast
+  acronym: SANE
+  year: 2026
+  deadline: 2026-10-10 23:59
+  start: 2026-10-30
+  end: 2026-10-30
+  place: "Cambridge, Massachusetts, USA"
+  url: https://www.saneworkshop.org/sane2026/
+  note: "One-day workshop; date shown is the poster submission deadline (no timezone published — treated as AoE)."
+
 - name: ACL Rolling Review
   acronym: ARR
   year: 2026
@@ -109,3 +129,14 @@
   end: 2026-12-06
   place: "Sydney, Australia"
   url: https://neurips.cc/Conferences/2026
+
+- name: AAAI Conference on Artificial Intelligence
+  acronym: AAAI
+  year: 2027
+  ccfddl: AI/aaai
+  abstract_deadline: 2026-07-21 23:59
+  deadline: 2026-07-28 23:59
+  start: 2027-02-16
+  end: 2027-02-23
+  place: "Montréal, Québec, Canada"
+  url: https://aaai.org/conference/aaai/aaai-27/

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,0 +1,111 @@
+# -----------------------------------------------------------------------------
+# Conference deadline tracker  ->  rendered at /conferences/
+# -----------------------------------------------------------------------------
+# This is the ONLY file you need to edit to maintain the conference list.
+# Each cycle, update `deadline` / `abstract_deadline` / `start` / `end` / `place`.
+#
+# Fields per entry:
+#   name              full conference name (string)
+#   acronym           short label shown on the card, e.g. ICASSP
+#   year              edition year (number) shown next to the acronym
+#   abstract_deadline (optional) "YYYY-MM-DD HH:MM" abstract/registration deadline
+#   deadline          "YYYY-MM-DD HH:MM" full paper submission deadline
+#   utc_offset        (optional) deadline timezone as UTC offset in hours.
+#                     OMIT for "Anywhere on Earth" (AoE), which is UTC-12 (default).
+#                     Examples: -5 = US Eastern (EST), 1 = Central Europe (CET).
+#   start             "YYYY-MM-DD" conference start date
+#   end               "YYYY-MM-DD" conference end date
+#   place             city, country  (used for the location line)
+#   url               official conference website
+#   note              (optional) short free-text note shown under the card
+#   ccfddl            (optional) path into the ccfddl/ccf-deadlines dataset,
+#                     e.g. "CG/icassp". Entries with this key are auto-refreshed
+#                     by .github/workflows/update-conferences.yml, which opens a
+#                     PR with proposed updates for review. The refresh overwrites
+#                     the volatile fields (year, deadlines, dates, place, url,
+#                     note) but preserves name/acronym. Entries WITHOUT this
+#                     key (e.g. ARR) are maintained entirely by hand.
+#
+# The page computes live countdowns client-side and sorts by soonest deadline;
+# passed deadlines automatically grey out and drop to the bottom.
+#
+# !! Always verify against the official site before relying on any date. !!
+# -----------------------------------------------------------------------------
+
+- name: IEEE International Conference on Acoustics, Speech and Signal Processing
+  acronym: ICASSP
+  year: 2027
+  ccfddl: CG/icassp
+  deadline: 2026-09-16 23:59
+  start: 2027-05-16
+  end: 2027-05-21
+  place: "Toronto, Canada"
+  url: https://2027.ieeeicassp.org/
+
+- name: Conference of the International Speech Communication Association
+  acronym: Interspeech
+  year: 2026
+  ccfddl: CG/interspeech
+  abstract_deadline: 2026-02-25 23:59
+  deadline: 2026-03-04 23:59
+  utc_offset: 0
+  start: 2026-09-27
+  end: 2026-10-01
+  place: "Sydney, Australia"
+  url: https://interspeech2026.org/
+
+- name: IEEE Spoken Language Technology Workshop
+  acronym: SLT
+  year: 2026
+  ccfddl: CG/slt
+  deadline: 2026-06-17 23:59
+  start: 2026-12-13
+  end: 2026-12-16
+  place: "Palermo, Sicily, Italy"
+  url: https://attend.ieee.org/slt-2026/
+
+- name: ACL Rolling Review
+  acronym: ARR
+  year: 2026
+  deadline: 2026-08-03 23:59
+  start: TBA
+  end: TBA
+  place: "Online (monthly cycle)"
+  url: https://aclrollingreview.org/dates
+  note: "ARR runs monthly cycles; update to the next submission deadline."
+
+- name: International Conference on Machine Learning
+  acronym: ICML
+  year: 2026
+  ccfddl: AI/icml
+  abstract_deadline: 2026-01-24 11:59
+  deadline: 2026-01-29 11:59
+  utc_offset: 0
+  start: 2026-07-06
+  end: 2026-07-12
+  place: "Seoul, Korea"
+  url: https://icml.cc/Conferences/2026
+  note: "Paper Submissions Open on OpenReview Jan 08 2026 12:00AM UTC-0"
+
+- name: International Conference on Learning Representations
+  acronym: ICLR
+  year: 2026
+  ccfddl: AI/iclr
+  abstract_deadline: 2025-09-19 23:59
+  deadline: 2025-09-24 23:59
+  start: 2026-05-01
+  end: 2026-05-05
+  place: "Brazil"
+  url: https://iclr.cc/Conferences/2026
+
+- name: Conference on Neural Information Processing Systems
+  acronym: NeurIPS
+  year: 2026
+  ccfddl: AI/nips
+  abstract_deadline: 2026-05-05 11:59
+  deadline: 2026-05-07 11:59
+  utc_offset: 0
+  start: 2026-12-06
+  end: 2026-12-06
+  place: "Sydney, Australia"
+  url: https://neurips.cc/Conferences/2026

--- a/_pages/conferences.md
+++ b/_pages/conferences.md
@@ -3,8 +3,7 @@ layout: page
 permalink: /conferences/
 title: Conferences
 description: Submission deadlines and dates for conferences the lab follows. Countdowns use your local timezone; deadlines without a timezone are Anywhere-on-Earth (UTC-12).
-nav: true
-order: 11
+nav: false
 ---
 
 <style>

--- a/_pages/conferences.md
+++ b/_pages/conferences.md
@@ -1,0 +1,163 @@
+---
+layout: page
+permalink: /conferences/
+title: Conferences
+description: Submission deadlines and dates for conferences the lab follows. Countdowns use your local timezone; deadlines without a timezone are Anywhere-on-Earth (UTC-12).
+nav: true
+order: 11
+---
+
+<style>
+  .conf-tracker { margin-top: 1rem; }
+  .conf-card {
+    border: 1px solid var(--global-divider-color);
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+    margin-bottom: 1rem;
+    background-color: var(--global-bg-color);
+    transition: opacity 0.2s ease;
+  }
+  .conf-card.past { opacity: 0.5; }
+  .conf-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+  .conf-acronym { font-size: 1.4rem; font-weight: 700; color: var(--global-theme-color); }
+  .conf-year { font-weight: 400; color: var(--global-text-color-light); font-size: 1.1rem; }
+  .conf-name { color: var(--global-text-color-light); font-size: 0.9rem; margin-bottom: 0.5rem; }
+  .conf-countdown {
+    font-variant-numeric: tabular-nums;
+    font-size: 1.15rem;
+    font-weight: 600;
+    margin: 0.5rem 0;
+  }
+  .conf-countdown .num { color: var(--global-theme-color); }
+  .conf-card.past .conf-countdown { color: var(--global-text-color-light); }
+  .conf-meta { font-size: 0.9rem; line-height: 1.6; }
+  .conf-meta .label { color: var(--global-text-color-light); display: inline-block; min-width: 5.5rem; }
+  .conf-note { font-size: 0.8rem; color: var(--global-text-color-light); margin-top: 0.4rem; font-style: italic; }
+  .conf-empty { color: var(--global-text-color-light); }
+</style>
+
+<p class="conf-empty">
+  This list is maintained manually, so deadlines and dates may be out of date or
+  contain errors — always check each conference's official site for the latest,
+  authoritative information. Countdowns below update live in your local timezone.
+</p>
+
+<div class="conf-tracker" id="conf-tracker">
+  {% for c in site.data.conferences %}
+  <div class="conf-card"
+       data-deadline="{{ c.deadline | date: '%Y-%m-%d %H:%M' }}"
+       data-abstract="{{ c.abstract_deadline | date: '%Y-%m-%d %H:%M' }}"
+       data-offset="{{ c.utc_offset | default: -12 }}">
+    <div class="conf-head">
+      <span class="conf-acronym">{{ c.acronym }} <span class="conf-year">{{ c.year }}</span></span>
+    </div>
+    <div class="conf-name">{{ c.name }}</div>
+    <div class="conf-countdown">…</div>
+    <div class="conf-meta">
+      {% if c.abstract_deadline %}
+      <div><span class="label">Abstract:</span> <span class="conf-abstract-local"></span></div>
+      {% endif %}
+      <div><span class="label">Paper:</span> <span class="conf-deadline-local"></span></div>
+      <div><span class="label">📅 Dates:</span>
+        {% if c.start == 'TBA' or c.start == 'TBD' or c.start == nil or c.start == '' %}TBD{% else %}{{ c.start | date: '%b %-d' }}{% if c.end and c.end != c.start %} – {{ c.end | date: '%b %-d, %Y' }}{% else %}, {{ c.start | date: '%Y' }}{% endif %}{% endif %}
+      </div>
+      <div><span class="label">📍 Place:</span> {{ c.place | default: 'TBD' }}</div>
+      {% if c.url %}<div><span class="label">🔗 Site:</span> <a href="{{ c.url }}" target="_blank" rel="noopener">{{ c.url | remove: 'https://' | remove: 'http://' | remove_first: 'www.' | split: '/' | first }}</a></div>{% endif %}
+    </div>
+    {% if c.note %}<div class="conf-note">{{ c.note }}</div>{% endif %}
+  </div>
+  {% endfor %}
+</div>
+
+<script>
+(function () {
+  // Parse a "YYYY-MM-DD HH:MM" wall-clock string in a given UTC offset (hours)
+  // into an absolute epoch (ms). AoE default offset (-12) is applied by Liquid.
+  function toEpoch(str, offsetHours) {
+    if (!str) return null;
+    var m = str.match(/(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2})/);
+    if (!m) return null;
+    var utcAsWall = Date.UTC(+m[1], +m[2] - 1, +m[3], +m[4], +m[5]);
+    return utcAsWall - offsetHours * 3600 * 1000; // UTC = wall - offset
+  }
+
+  function fmtLocal(epoch) {
+    if (epoch == null) return "—";
+    try {
+      var d = new Date(epoch);
+      return d.toLocaleString(undefined, {
+        year: "numeric", month: "short", day: "numeric",
+        hour: "2-digit", minute: "2-digit", timeZoneName: "short"
+      });
+    } catch (e) { return new Date(epoch).toString(); }
+  }
+
+  function fmtCountdown(ms) {
+    if (ms <= 0) return '<span style="font-weight:600">Deadline passed</span>';
+    var s = Math.floor(ms / 1000);
+    var d = Math.floor(s / 86400); s -= d * 86400;
+    var h = Math.floor(s / 3600);  s -= h * 3600;
+    var m = Math.floor(s / 60);    s -= m * 60;
+    return '<span class="num">' + d + '</span>d ' +
+           '<span class="num">' + h + '</span>h ' +
+           '<span class="num">' + m + '</span>m ' +
+           '<span class="num">' + s + '</span>s';
+  }
+
+  var tracker = document.getElementById("conf-tracker");
+  if (!tracker) return;
+  var cards = Array.prototype.slice.call(tracker.querySelectorAll(".conf-card"));
+
+  cards.forEach(function (card) {
+    var off = parseFloat(card.getAttribute("data-offset"));
+    if (isNaN(off)) off = -12;
+    card.deadlineEpoch = toEpoch(card.getAttribute("data-deadline"), off);
+    card.abstractEpoch = toEpoch(card.getAttribute("data-abstract"), off);
+    var dl = card.querySelector(".conf-deadline-local");
+    if (dl) dl.textContent = fmtLocal(card.deadlineEpoch);
+    var ab = card.querySelector(".conf-abstract-local");
+    if (ab) ab.textContent = fmtLocal(card.abstractEpoch);
+  });
+
+  // Sort: upcoming deadlines first (soonest at top); passed deadlines after,
+  // most-recently-passed first. Entries without a deadline sink to the bottom.
+  function sortCards() {
+    var now = Date.now();
+    cards.sort(function (a, b) {
+      var ea = a.deadlineEpoch, eb = b.deadlineEpoch;
+      if (ea == null) return 1;
+      if (eb == null) return -1;
+      var ap = ea < now, bp = eb < now;
+      if (ap !== bp) return ap ? 1 : -1;     // future before past
+      if (!ap) return ea - eb;               // both future: soonest first
+      return eb - ea;                        // both past: most recent first
+    });
+    cards.forEach(function (card) {
+      card.classList.toggle("past", card.deadlineEpoch != null && card.deadlineEpoch < now);
+      tracker.appendChild(card);
+    });
+  }
+
+  function tick() {
+    var now = Date.now();
+    cards.forEach(function (card) {
+      var cd = card.querySelector(".conf-countdown");
+      if (!cd) return;
+      if (card.deadlineEpoch == null) { cd.textContent = "No deadline set"; return; }
+      cd.innerHTML = fmtCountdown(card.deadlineEpoch - now);
+    });
+  }
+
+  sortCards();
+  tick();
+  // Re-sort once a minute (so a card flips to "past" without a reload); tick each second.
+  setInterval(tick, 1000);
+  setInterval(sortCards, 60000);
+})();
+</script>

--- a/_pages/conferences.md
+++ b/_pages/conferences.md
@@ -49,14 +49,16 @@ nav: false
 
 <div class="conf-tracker" id="conf-tracker">
   {% for c in site.data.conferences %}
+  {% comment %} Data may be auto-refreshed from a third-party dataset, so every
+  field is HTML-escaped and links are restricted to http(s) to avoid injection. {% endcomment %}
   <div class="conf-card"
-       data-deadline="{{ c.deadline | date: '%Y-%m-%d %H:%M' }}"
-       data-abstract="{{ c.abstract_deadline | date: '%Y-%m-%d %H:%M' }}"
+       data-deadline="{{ c.deadline | date: '%Y-%m-%d %H:%M' | escape }}"
+       data-abstract="{{ c.abstract_deadline | date: '%Y-%m-%d %H:%M' | escape }}"
        data-offset="{{ c.utc_offset | default: -12 }}">
     <div class="conf-head">
-      <span class="conf-acronym">{{ c.acronym }} <span class="conf-year">{{ c.year }}</span></span>
+      <span class="conf-acronym">{{ c.acronym | escape }} <span class="conf-year">{{ c.year }}</span></span>
     </div>
-    <div class="conf-name">{{ c.name }}</div>
+    <div class="conf-name">{{ c.name | escape }}</div>
     <div class="conf-countdown">…</div>
     <div class="conf-meta">
       {% if c.abstract_deadline %}
@@ -66,10 +68,17 @@ nav: false
       <div><span class="label">📅 Dates:</span>
         {% if c.start == 'TBA' or c.start == 'TBD' or c.start == nil or c.start == '' %}TBD{% else %}{{ c.start | date: '%b %-d' }}{% if c.end and c.end != c.start %} – {{ c.end | date: '%b %-d, %Y' }}{% else %}, {{ c.start | date: '%Y' }}{% endif %}{% endif %}
       </div>
-      <div><span class="label">📍 Place:</span> {{ c.place | default: 'TBD' }}</div>
-      {% if c.url %}<div><span class="label">🔗 Site:</span> <a href="{{ c.url }}" target="_blank" rel="noopener">{{ c.url | remove: 'https://' | remove: 'http://' | remove_first: 'www.' | split: '/' | first }}</a></div>{% endif %}
+      <div><span class="label">📍 Place:</span> {{ c.place | default: 'TBD' | escape }}</div>
+      {% if c.url %}
+        {% assign u = c.url | strip %}
+        {% assign u_https = u | slice: 0, 8 | downcase %}
+        {% assign u_http = u | slice: 0, 7 | downcase %}
+        {% if u_https == 'https://' or u_http == 'http://' %}
+        <div><span class="label">🔗 Site:</span> <a href="{{ u | escape }}" target="_blank" rel="noopener">{{ u | remove_first: 'https://' | remove_first: 'http://' | remove_first: 'www.' | split: '/' | first | escape }}</a></div>
+        {% endif %}
+      {% endif %}
     </div>
-    {% if c.note %}<div class="conf-note">{{ c.note }}</div>{% endif %}
+    {% if c.note %}<div class="conf-note">{{ c.note | escape }}</div>{% endif %}
   </div>
   {% endfor %}
 </div>

--- a/_pages/info.md
+++ b/_pages/info.md
@@ -8,6 +8,7 @@ order: 8
 
 This page has some information and guidelines for members of WAVLab.
 
+* [Conference deadline tracker]({{ '/conferences/' | relative_url }}) — live countdowns for conferences the lab follows
 * [TIR cluster use instructions (for ESPnet user)]({% post_url 2022-01-01-tir-usage %})
 * [AWS use instructions]({% post_url 2022-01-01-aws-usage %})
 * [PSC cluster use instructions]({% post_url 2022-01-01-psc-usage %})

--- a/scripts/update_conferences.py
+++ b/scripts/update_conferences.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Refresh _data/conferences.yml deadline/date fields from ccfddl/ccf-deadlines.
+
+Only entries that carry a ``ccfddl:`` key (e.g. ``ccfddl: CG/icassp``) are
+touched. Identity / curation fields (name, acronym, ccfddl) are
+preserved; the script overwrites only the volatile fields:
+year, abstract_deadline, deadline, utc_offset, start, end, place, url, note.
+
+Entries without ``ccfddl:`` (e.g. ARR) are left untouched for manual
+maintenance.
+
+For each tracked conference the script picks the *next upcoming* edition (the
+soonest deadline still in the future); if every deadline has passed it falls
+back to the latest available year.
+
+Run from anywhere; paths are resolved relative to this file. Intended for the
+scheduled GitHub Action, which opens a PR with the diff for human review.
+
+Dependencies: ruamel.yaml  (pip install ruamel.yaml)
+"""
+from __future__ import annotations
+
+import datetime as dt
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+RAW_BASE = "https://raw.githubusercontent.com/ccfddl/ccf-deadlines/main/conference/"
+DATA_FILE = Path(__file__).resolve().parent.parent / "_data" / "conferences.yml"
+
+_MONTHS = {
+    "january": 1, "february": 2, "march": 3, "april": 4, "may": 5, "june": 6,
+    "july": 7, "august": 8, "september": 9, "october": 10, "november": 11,
+    "december": 12,
+}
+# also accept 3-letter abbreviations (jan, feb, ...) and "sept"
+_MONTHS.update({name[:3]: num for name, num in list(_MONTHS.items())})
+_MONTHS["sept"] = 9
+
+# Canonical key order and quoting for deterministic emission (clean PR diffs).
+_KEY_ORDER = [
+    "name", "acronym", "year", "ccfddl",
+    "abstract_deadline", "deadline", "utc_offset",
+    "start", "end", "place", "url", "note",
+]
+_QUOTED_KEYS = {"place", "note"}
+
+yaml = YAML(typ="safe")
+
+
+def fetch(path: str):
+    """Load a ccfddl conference YAML file (e.g. 'CG/icassp')."""
+    url = f"{RAW_BASE}{path}.yml"
+    req = urllib.request.Request(url, headers={"User-Agent": "wavlab-conf-bot"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return yaml.load(resp.read().decode("utf-8"))
+
+
+def parse_deadline(value: str | None) -> dt.datetime | None:
+    if not value or value == "TBD":
+        return None
+    m = re.match(r"(\d{4})-(\d{2})-(\d{2})\s+(\d{2}):(\d{2})", str(value))
+    if not m:
+        return None
+    y, mo, d, h, mi = (int(x) for x in m.groups())
+    try:
+        return dt.datetime(y, mo, d, h, mi)
+    except ValueError:
+        return None
+
+
+def fmt_deadline(value: str | None) -> str | None:
+    """'YYYY-MM-DD HH:MM:SS' -> 'YYYY-MM-DD HH:MM' (drop seconds); None if TBD."""
+    if not value or value == "TBD":
+        return None
+    m = re.match(r"(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2})", str(value))
+    return f"{m.group(1)} {m.group(2)}" if m else None
+
+
+def parse_date_range(value: str | None):
+    """Parse ccfddl 'date' strings into (start_iso, end_iso).
+
+    Handles e.g. 'May 16-21, 2027', 'September 27 - October 1, 2026',
+    'May 01-05, 2026', 'December 6, 2026'. Returns (None, None) on failure.
+    """
+    if not value:
+        return None, None
+    m = re.match(
+        r"^\s*([A-Za-z]+)\s+(\d{1,2})"          # start month + day
+        r"(?:\s*-\s*(?:([A-Za-z]+)\s+)?(\d{1,2}))?"  # optional end (month?) day
+        r"\s*,\s*(\d{4})\s*$",                  # year
+        str(value),
+    )
+    if not m:
+        return None, None
+    mon1, day1, mon2, day2, year = m.groups()
+    start_mo = _MONTHS.get(mon1.lower())
+    if not start_mo:
+        return None, None
+    year = int(year)
+    start_day = int(day1)
+    if day2 is None:                       # single-day conference
+        end_mo, end_day = start_mo, start_day
+    else:
+        end_mo = _MONTHS.get(mon2.lower(), start_mo) if mon2 else start_mo
+        end_day = int(day2)
+    start_year = end_year = year
+    if end_mo < start_mo:                  # crosses the new year (e.g. Dec-Jan)
+        end_year = year + 1
+    try:
+        start = dt.date(start_year, start_mo, start_day)
+        end = dt.date(end_year, end_mo, end_day)
+    except ValueError:
+        return None, None
+    return start.isoformat(), end.isoformat()
+
+
+def tz_to_offset(tz: str | None):
+    """'AoE'->-12, 'UTC'->0, 'UTC-7'->-7, 'UTC+8'->8; None if unrecognized."""
+    if not tz or tz == "AoE":
+        return -12
+    m = re.match(r"^UTC([+-]\d+)?$", tz)
+    if not m:
+        return None
+    return int(m.group(1)) if m.group(1) else 0
+
+
+def pick_edition(confs):
+    """Pick the soonest future deadline; else the latest year."""
+    now = dt.datetime.utcnow()
+    parsed = []
+    for conf in confs:
+        timeline = (conf.get("timeline") or [{}])[0]
+        deadline = parse_deadline(timeline.get("deadline"))
+        parsed.append((deadline, int(conf.get("year", 0)), conf))
+    future = [p for p in parsed if p[0] and p[0] >= now]
+    if future:
+        return min(future, key=lambda p: p[0])[2]
+    return max(parsed, key=lambda p: p[1])[2]
+
+
+def update_entry(entry) -> str:
+    doc = fetch(entry["ccfddl"])
+    meta = doc[0]
+    conf = pick_edition(meta["confs"])
+    timeline = (conf.get("timeline") or [{}])[0]
+
+    entry["year"] = int(conf["year"])
+
+    deadline = fmt_deadline(timeline.get("deadline"))
+    note_bits = []
+    if deadline:
+        entry["deadline"] = deadline
+    else:
+        note_bits.append("Next deadline TBD on ccfddl — verify on the official site.")
+
+    abstract = fmt_deadline(timeline.get("abstract_deadline"))
+    if abstract:
+        entry["abstract_deadline"] = abstract
+    elif "abstract_deadline" in entry:
+        del entry["abstract_deadline"]
+
+    offset = tz_to_offset(conf.get("timezone"))
+    if offset is None or offset == -12:   # -12 / AoE is our default -> omit key
+        if "utc_offset" in entry:
+            del entry["utc_offset"]
+    else:
+        entry["utc_offset"] = offset
+
+    start, end = parse_date_range(conf.get("date"))
+    if start:
+        entry["start"] = start
+        entry["end"] = end
+
+    if conf.get("link"):
+        entry["url"] = conf["link"]
+    if conf.get("place"):
+        entry["place"] = conf["place"]
+
+    comment = timeline.get("comment")
+    if comment:
+        note_bits.insert(0, str(comment))
+    if note_bits:
+        entry["note"] = " ".join(note_bits)
+    elif "note" in entry:
+        del entry["note"]
+
+    return f"{entry.get('acronym')} -> {entry['year']}"
+
+
+def _quote(value) -> str:
+    s = str(value)
+    return '"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def _format_value(key, value) -> str:
+    if key == "tags":
+        return "[" + ", ".join(str(t) for t in value) + "]"
+    if key in ("year", "utc_offset"):
+        return str(value)
+    if key in ("start", "end"):
+        if isinstance(value, (dt.date, dt.datetime)):
+            return value.strftime("%Y-%m-%d")
+        return str(value)
+    if key in ("deadline", "abstract_deadline"):
+        if isinstance(value, dt.datetime):
+            return value.strftime("%Y-%m-%d %H:%M")
+        return str(value)
+    if key in _QUOTED_KEYS:
+        return _quote(value)
+    return str(value)  # acronym, ccfddl, url — single tokens, safe unquoted
+
+
+def dump_entry(entry: dict) -> str:
+    lines = []
+    seen = set()
+    for key in _KEY_ORDER:
+        if key in entry and entry[key] is not None:
+            seen.add(key)
+            prefix = "- " if not lines else "  "
+            lines.append(f"{prefix}{key}: {_format_value(key, entry[key])}")
+    # Emit any unexpected extra keys last, so nothing is silently dropped.
+    for key in entry:
+        if key not in seen and entry[key] is not None:
+            lines.append(f"  {key}: {_format_value(key, entry[key])}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    text = DATA_FILE.read_text(encoding="utf-8")
+
+    # Preserve the leading comment/header block verbatim (everything before the
+    # first list item), so documentation isn't lost on round-trip.
+    body_lines = text.splitlines()
+    first_item = next((i for i, ln in enumerate(body_lines)
+                       if ln.startswith("- ")), len(body_lines))
+    header = "\n".join(body_lines[:first_item]).rstrip("\n")
+
+    data = yaml.load(text)
+    updated, failed = [], []
+    for entry in data:
+        if not isinstance(entry, dict) or "ccfddl" not in entry:
+            continue
+        try:
+            updated.append(update_entry(entry))
+        except Exception as exc:  # noqa: BLE001 - report and continue
+            failed.append(f"{entry.get('acronym')}: {exc}")
+
+    blocks = [dump_entry(e) for e in data if isinstance(e, dict)]
+    output = header + "\n\n" + "\n\n".join(blocks) + "\n"
+    DATA_FILE.write_text(output, encoding="utf-8")
+
+    print("Updated:", ", ".join(updated) if updated else "(none)")
+    if failed:
+        print("Failed:", "; ".join(failed), file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update_conferences.py
+++ b/scripts/update_conferences.py
@@ -62,7 +62,9 @@ def fetch(path: str):
 def parse_deadline(value: str | None) -> dt.datetime | None:
     if not value or value == "TBD":
         return None
-    m = re.match(r"(\d{4})-(\d{2})-(\d{2})\s+(\d{2}):(\d{2})", str(value))
+    # ccfddl timestamps include seconds (e.g. '2026-09-16 23:59:59'); the
+    # optional ':SS' group is matched and discarded so we never fall through.
+    m = re.match(r"(\d{4})-(\d{2})-(\d{2})\s+(\d{2}):(\d{2})(?::\d{2})?", str(value))
     if not m:
         return None
     y, mo, d, h, mi = (int(x) for x in m.groups())
@@ -76,7 +78,7 @@ def fmt_deadline(value: str | None) -> str | None:
     """'YYYY-MM-DD HH:MM:SS' -> 'YYYY-MM-DD HH:MM' (drop seconds); None if TBD."""
     if not value or value == "TBD":
         return None
-    m = re.match(r"(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2})", str(value))
+    m = re.match(r"(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2})(?::\d{2})?", str(value))
     return f"{m.group(1)} {m.group(2)}" if m else None
 
 
@@ -119,13 +121,26 @@ def parse_date_range(value: str | None):
 
 
 def tz_to_offset(tz: str | None):
-    """'AoE'->-12, 'UTC'->0, 'UTC-7'->-7, 'UTC+8'->8; None if unrecognized."""
+    """Convert a ccfddl timezone string to a UTC offset in hours.
+
+    'AoE'->-12, 'UTC'->0, 'UTC-7'->-7, 'UTC+8'->8, 'UTC+5:30'->5.5,
+    'UTC+5.5'->5.5; None if unrecognized. Whole offsets return int, fractional
+    ones return float (the page reads the value with parseFloat either way).
+    """
     if not tz or tz == "AoE":
         return -12
-    m = re.match(r"^UTC([+-]\d+)?$", tz)
+    if tz == "UTC":
+        return 0
+    m = re.match(r"^UTC([+-])(\d+)(?:([:.])(\d+))?$", tz)
     if not m:
         return None
-    return int(m.group(1)) if m.group(1) else 0
+    sign, hours, sep, frac = m.groups()
+    val = float(hours)
+    if frac is not None:
+        val += int(frac) / 60 if sep == ":" else float("0." + frac)
+    if sign == "-":
+        val = -val
+    return int(val) if val == int(val) else val
 
 
 def pick_edition(confs):
@@ -150,35 +165,49 @@ def update_entry(entry) -> str:
 
     entry["year"] = int(conf["year"])
 
+    # Volatile fields mirror ccfddl: when upstream no longer provides a value we
+    # drop the stale one rather than leaving an outdated date/link behind.
     deadline = fmt_deadline(timeline.get("deadline"))
     note_bits = []
     if deadline:
         entry["deadline"] = deadline
     else:
+        entry.pop("deadline", None)
         note_bits.append("Next deadline TBD on ccfddl — verify on the official site.")
 
     abstract = fmt_deadline(timeline.get("abstract_deadline"))
     if abstract:
         entry["abstract_deadline"] = abstract
-    elif "abstract_deadline" in entry:
-        del entry["abstract_deadline"]
+    else:
+        entry.pop("abstract_deadline", None)
 
     offset = tz_to_offset(conf.get("timezone"))
     if offset is None or offset == -12:   # -12 / AoE is our default -> omit key
-        if "utc_offset" in entry:
-            del entry["utc_offset"]
+        entry.pop("utc_offset", None)
     else:
         entry["utc_offset"] = offset
 
-    start, end = parse_date_range(conf.get("date"))
+    date_str = conf.get("date")
+    start, end = parse_date_range(date_str)
     if start:
         entry["start"] = start
         entry["end"] = end
+    elif not date_str:                     # upstream omitted dates -> drop stale
+        entry.pop("start", None)
+        entry.pop("end", None)
+    else:                                  # present but unparseable -> keep, flag
+        note_bits.append(
+            f"Unrecognized ccfddl date '{date_str}' — verify on the official site."
+        )
 
     if conf.get("link"):
         entry["url"] = conf["link"]
+    else:
+        entry.pop("url", None)
     if conf.get("place"):
         entry["place"] = conf["place"]
+    else:
+        entry.pop("place", None)
 
     comment = timeline.get("comment")
     if comment:
@@ -192,8 +221,15 @@ def update_entry(entry) -> str:
 
 
 def _quote(value) -> str:
-    s = str(value)
-    return '"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"'
+    # Backslash first, then quotes, then whitespace control chars, so a newline
+    # in upstream place/comment text can't break the double-quoted YAML scalar.
+    s = (str(value)
+         .replace("\\", "\\\\")
+         .replace('"', '\\"')
+         .replace("\n", "\\n")
+         .replace("\r", "\\r")
+         .replace("\t", "\\t"))
+    return '"' + s + '"'
 
 
 def _format_value(key, value) -> str:


### PR DESCRIPTION
## Summary
- New `/conferences/` page with live client-side countdowns (AoE default, rendered in the viewer's local timezone). Upcoming deadlines sort to the top; passed deadlines grey out and drop to the bottom.
- Linked from the **Info** page rather than the top navbar.
- Conference data lives in `_data/conferences.yml`: ICASSP, Interspeech, SLT, SLT Demo/Challenge, SANE, ARR, ICML, ICLR, NeurIPS, AAAI.
- Entries with a `ccfddl:` key are auto-refreshed weekly by `.github/workflows/update-conferences.yml` (runs `scripts/update_conferences.py`), which opens a PR with proposed changes for review — it never pushes to a deploy branch. Manual entries (ARR, SLT Demo/Challenge, SANE) are maintained by hand.

## Notes
- Data cross-checked against the live ccfddl dataset.
- ICLR 2026 has already concluded and ccfddl has no 2027 edition yet, so its card stays at 2026 (greyed out) until upstream updates.
- NeurIPS 2026 mirrors ccfddl, which lists a single day (Dec 6) and place "Sydney" — worth verifying against the official site.

## Test plan
- [x] `bundle exec jekyll build` succeeds locally
- [ ] `/conferences/` renders all cards with correct countdowns/formatting
- [ ] Passed deadlines grey out and sort below upcoming ones
- [ ] Conferences reachable from the Info page; not in the top navbar
